### PR TITLE
Fixes reconnections of mqtt client

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -158,7 +158,7 @@ function MQTTServer(adapter, states) {
         return null;
     }
 
-    function processTopic(id, topic, message, qos, retain, isAck, obj, ignoreClient) {
+    function processTopic(id, topic, message, qos, retain, isAck, obj, ignoreClient, cb) {
         // expand old version of objects
         if (obj && namespaceRegEx.test(id) && (!obj.native || !obj.native.topic)) {
             obj.native       = obj.native || {};
@@ -194,12 +194,14 @@ function MQTTServer(adapter, states) {
                 for (var k in clients) {
                     // if get and set have different topic names, send state to issuing client too.
                     if (clients[k] === ignoreClient && !adapter.config.extraSet) continue;
-                    sendState2Client(clients[k], id, message, qos, retain);
+                    sendState2Client(clients[k], id, message, qos, retain, cb);
                 }
             });
         }
         // ELSE
         // this will be done indirect. Message will be sent to js-controller and if adapter is subscribed, it gets this message over stateChange
+
+        if (cb) cb();
     }
 
     function checkObject(id, topic, message, qos, retain, isAck, ignoreClient) {
@@ -279,7 +281,7 @@ function MQTTServer(adapter, states) {
         return pattern;
     }
 
-    function receivedTopic(packet, client) {
+    function receivedTopic(packet, client, cb) {
         var isAck   = true;
         var topic   = packet.topic;
         var message = packet.payload;
@@ -295,11 +297,13 @@ function MQTTServer(adapter, states) {
             });
         } else if (qos === 2) {
             var pack = qos2queue.find(function (e) {
+                if (cb) cb();
                 return e.id === packet.messageId;
             });
             if (pack) {
                 // duplicate message => ignore
                 adapter.log.warn('Ignored duplicate message with ID: ' + packet.messageId);
+                if (cb) cb();
                 return;
             } else {
                 qos2queue.push({id: packet.messageId, ts: now});
@@ -334,6 +338,7 @@ function MQTTServer(adapter, states) {
 
         if (!id) {
             adapter.log.error('Invalid topic name: ' + JSON.stringify(topic));
+            if (cb) cb();
             return;
         }
 
@@ -365,6 +370,7 @@ function MQTTServer(adapter, states) {
         // If state is unknown => create mqtt.X.topic
         if ((adapter.namespace + '.' + id).length > adapter.config.maxTopicLength) {
             adapter.log.warn('Topic name is too long: ' + id.substring(0, 100) + '...');
+            if (cb) cb();
             return;
         }
 
@@ -416,14 +422,16 @@ function MQTTServer(adapter, states) {
 
         if (!topic2id[topic]) {
             checkObject(id, topic, message, qos, retain, isAck, client);
+            if (cb) cb();
         } else if (topic2id[topic].id === null) {
             topic2id[topic].message = message;
             // still looking for id
             if (adapter.config.debug) adapter.log.debug('Server received (but in process) "' + topic + '" (' + typeof message + '): ' + message);
+            if (cb) cb();
         } else {
             if (topic2id[topic].message !== undefined) delete topic2id[topic].message;
 
-            processTopic(topic2id[topic].id, topic, message, qos, retain, isAck, null, client);
+            processTopic(topic2id[topic].id, topic, message, qos, retain, isAck, null, client, cb);
         }
     }
 
@@ -440,9 +448,16 @@ function MQTTServer(adapter, states) {
                 adapter.log.info('Client [' + client.id + '] ' + reason);
                 delete clients[client.id];
                 updateClients();
-                if (client._will) receivedTopic(client._will);
+                if (client._will) {
+                    receivedTopic(client._will, client, function() {
+                        client.stream.end();
+                    });
+                } else {
+                    client.stream.end();
+                }
+            } else {
+                client.stream.end();
             }
-            client.stream.end();
         } catch (e) {
             adapter.log.warn('Cannot close client: ' + e);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -441,10 +441,8 @@ function MQTTServer(adapter, states) {
                 delete clients[client.id];
                 updateClients();
                 if (client._will) receivedTopic(client._will);
-                client.destroy();
-            } else {
-                client.destroy();
             }
+            client.stream.end();
         } catch (e) {
             adapter.log.warn('Cannot close client: ' + e);
         }
@@ -471,9 +469,9 @@ function MQTTServer(adapter, states) {
                             // delete existing client
                             delete clients[client.id];
                             updateClients();
-                            oldClient.destroy();
+                            oldClient.stream.end();
                         }                        
-                        client.destroy();
+                        client.stream.end();
                         return;
                     }
                 }
@@ -481,7 +479,7 @@ function MQTTServer(adapter, states) {
                 if (oldClient) {
                     adapter.log.info('Client [' + client.id + '] reconnected');
                     // need to destroy the old client
-                    oldClient.destroy();    
+                    oldClient.stream.end();  
                 } else {
                     adapter.log.info('Client [' + client.id + '] connected');
                 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -427,24 +427,65 @@ function MQTTServer(adapter, states) {
         }
     }
 
+   function clientClose(client, reason) {
+        if (!client) return;
+
+        if (client._sendOnStart) {
+           clearTimeout(client._sendOnStart);
+           client._sendOnStart = null;
+        }
+
+        try {
+            if (clients[client.id] && (client.timestamp === clients[client.id].timestamp)) {
+                adapter.log.info('Client [' + client.id + '] ' + reason);
+                delete clients[client.id];
+                updateClients();
+                if (client._will) receivedTopic(client._will);
+                client.destroy();
+            } else {
+                client.destroy();
+            }
+        } catch (e) {
+            adapter.log.warn('Cannot close client: ' + e);
+        }
+    }
+
     var _constructor = (function (config) {
         var cltFunction = function (client) {
 
             client.on('connect', function (options) {
+                // set client id
                 client.id = options.clientId;
+                // store unique timestamp with each client
+                client.timestamp = new Date().getTime();
+                
+                // get possible old client
+                let oldClient = clients[client.id];
+                
                 if (config.user) {
                     if (config.user !== options.username ||
                         config.pass !== (options.password || '').toString()) {
                         adapter.log.warn('Client [' + options.clientId + '] has invalid password(' + options.password + ') or username(' + options.username + ')');
                         client.connack({returnCode: 4});
-                        if (clients[client.id]) delete clients[client.id];
-                        client.stream.end();
-                        updateClients();
+                        if (oldClient) {
+                            // delete existing client
+                            delete clients[client.id];
+                            updateClients();
+                            oldClient.destroy();
+                        }                        
+                        client.destroy();
                         return;
                     }
                 }
 
-                adapter.log.info('Client [' + options.clientId + '] connected');
+                if (oldClient) {
+                    adapter.log.info('Client [' + client.id + '] reconnected');
+                    // need to destroy the old client
+                    oldClient.destroy();    
+                } else {
+                    adapter.log.info('Client [' + client.id + '] connected');
+                }
+
                 client.connack({returnCode: 0});
                 clients[client.id] = client;
                 updateClients();
@@ -578,53 +619,19 @@ function MQTTServer(adapter, states) {
                 client.suback({granted: granted, messageId: packet.messageId});
             });
 
-            client.on('pingreq', function (/*packet*/) {
-                adapter.log.debug('Client [' + client.id + '] pingreq');
-                client.pingresp();
-            });
-
-            client.on('disconnect', function (/*packet*/) {
-                if (client._sendOnStart) {
-                    clearTimeout(client._sendOnStart);
-                    client._sendOnStart = null;
-                }
-                adapter.log.info('Client [' + client.id + '] disconnected');
-                client.stream.end();
-                if (clients[client.id]) {
-                    delete clients[client.id];
-                    if (client._will) receivedTopic(client._will);
-                    updateClients();
+            client.on('pingreq', (/*packet*/) => {
+                if (clients[client.id] && (client.timestamp === clients[client.id].timestamp)) {
+                    adapter.log.debug('Client [' + client.id + '] pingreq');
+                    client.pingresp();
+                } else {
+                    adapter.log.info('Received pingreq from disconnected client "' + client.id + '"');
                 }
             });
 
-            client.on('close', function (had_error) {
-                if (client._sendOnStart) {
-                    clearTimeout(client._sendOnStart);
-                    client._sendOnStart = null;
-                }
-                if (had_error) adapter.log.error('Closed because of error');
-                adapter.log.info('Client [' + client.id + '] closed');
-                if (clients[client.id]) {
-                    delete clients[client.id];
-                    if (client._will) receivedTopic(client._will);
-                    updateClients();
-                }
-            });
-
-            client.on('error', function (err) {
-                if (client._sendOnStart) {
-                    clearTimeout(client._sendOnStart);
-                    client._sendOnStart = null;
-                }
-                adapter.log.warn('Client error [' + client.id + ']: ' + err);
-
-                if (!clients[client.id]) return;
-
-                delete clients[client.id];
-                if (client._will) receivedTopic(client._will);
-                updateClients();
-                client.stream.end();
-            });
+            // connection error handling
+            client.on('close',      had_error => clientClose(client, had_error ? 'closed because of error' : 'closed'));
+            client.on('error',      e  => clientClose(client, e));
+            client.on('disconnect', () => clientClose(client, 'disconnected'));
         };
 
         var serverConfig = {};


### PR DESCRIPTION
1.) Each client will have a unique timestamp when the client is created.
2.) During reconnected the old client connection will be destroyed.
3.) In error,close or disconnected case the client will be destroyed; but the client list will onbly be updated if the timestamps match.

Review should be done on callback handling in case of client close,error or disconnect.