### PR TITLE
Added handling of timeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -711,13 +711,12 @@ function MQTTServer(adapter, states) {
                 }
                       
                 //set timeout for stream to 1,5 times keepalive [MQTT-3.1.2-24].
-                if ( client._keepalive !== 0 ){
+                if (client._keepalive !== 0) {
                       let streamtimeout_sec = 1.5 * client._keepalive;
                       stream.setTimeout(streamtimeout_sec * 1000);
                       
                       adapter.log.debug(`Client [${client.id}] with keepalive ${client._keepalive} set timeout to ${streamtimeout_sec} seconds`);
                 }
-                      
             });
 
             client.on('publish', packet => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -599,6 +599,8 @@ function MQTTServer(adapter, states) {
                 // set client id
                 client.id = options.clientId;
                 client.cleanSession = options.cleanSession;
+                      
+                client._keepalive = options.keepalive;
 
                 // get possible old client
                 let oldClient = clients[client.id];
@@ -674,6 +676,10 @@ function MQTTServer(adapter, states) {
                         id = convertTopic2id(client._will.topic, false, config.prefix, adapter.namespace);
                     }
                     checkObject(id, client._will.topic);
+                    
+                    //something went wrong while JSON.parse, so payload of last will not handeled correct as buffer
+                    client._will.payload = options.will.payload;
+                    adapter.log.debug(`Client [${client.id}] with last will ${JSON.stringify(client._will)}`);
                 }
 
                 // Send all subscribed variables to client
@@ -703,6 +709,15 @@ function MQTTServer(adapter, states) {
                         }, 100, client.id);
                     }
                 }
+                      
+                //set timeout for stream to 1,5 times keepalive [MQTT-3.1.2-24].
+                if ( client._keepalive !== 0 ){
+                      let streamtimeout_sec = 1.5 * client._keepalive;
+                      stream.setTimeout(streamtimeout_sec * 1000);
+                      
+                      adapter.log.debug(`Client [${client.id}] with keepalive ${client._keepalive} set timeout to ${streamtimeout_sec} seconds`);
+                }
+                      
             });
 
             client.on('publish', packet => {
@@ -1013,6 +1028,9 @@ function MQTTServer(adapter, states) {
             client.on('close',      had_error => clientClose(client, had_error ? 'closed because of error' : 'closed'));
             client.on('error',      e  => clientClose(client, e));
             client.on('disconnect', () => clientClose(client, 'disconnected'));
+                      
+            // client lost without close
+            stream.on('timeout', () => clientClose(client, 'timeout'));
 
         });
         (server || socket).listen(port, bind, () => {


### PR DESCRIPTION
Added timeout handling as required in [MQTT-3.1.2-24].
Helps also to not have stalling TCP connections when clients did not disconnect.
Last will is now correct handeled at timeout.