### PR TITLE
Send state as object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ admin/i18n/flat.txt
 admin/i18n/*/flat.txt
 iob_npm.done
 package-lock.json
+
+build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ admin/i18n/flat.txt
 admin/i18n/*/flat.txt
 iob_npm.done
 package-lock.json
-
-build.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This adapter uses the MQTT.js library from https://github.com/adamvr/MQTT.js/
 - **Test connection** - Press the button to check the connection to broker. Adapter must be enabled before.
 - **Send states (ack=true) too** - Normally only the states/commands with ack=false will be sent to partner. If this flag is set every state independent from ack will be sent to partner. 
 - **Use different topic names for set and get** - if active, so every state will have two topics: ```adapter/instance/stateName``` and ```adapter/instance/stateName/set```. In this case topic with "/set" will be used to send non acknowledged commands (ack: false) and topic without "/set" to receive state updates (with ack: true).
+- **Send state object as mqtt message** - The client sends the states as parsed string JSON objects to the broker (example parsed string JSON object: ```{"val":true,"ack":true,"ts":1584690242021,"q":0,"from":"system.adapter.deconz.0","user":"system.user.admin","lc":1584624242021,"expire":true}```); if not the values ```states.val``` is sent as a single value (example state.val as single value: ```true```)
 - **Persistent Session** - When checked the broker saves the session information of the adapter. This means it tracks which messages have been send / received by the adapter (only QoS Level 1 and 2) and to which topics the adapter has subscribed. This information survives a disconnect and reconnect of the adapter.
 
 ## Install

--- a/admin/index.html
+++ b/admin/index.html
@@ -142,6 +142,7 @@
         $('#tabs').tabs();
 		onChange = _onChange;
         settings.sendAckToo = settings.sendAckToo || false;
+        settings.sendStateObject = settings.sendStateObject || false;
         settings.webSocket  = settings.webSocket  || false;
         if (settings.sendOnStartInterval === undefined) settings.sendOnStartInterval = 2000;
         if (settings.sendInterval === undefined) settings.sendInterval = 10;
@@ -351,9 +352,14 @@
                     <td></td>
                 </tr>
                 <tr>
+                    <td><label class="translate" for="sendStateObject">Send state object as mqtt message 2222</label></td>
+                    <td><input id="sendStateObject" type="checkbox" class="value"/></td>
+                    <td></td>
+                </tr>
+                <tr>
                     <td><label class="translate" for="maxTopicLength">Max topic length:</label></td>
-                    <td><input id="maxTopicLength" class="value" size="17"/></td>
-                    <td class="translate">chars</td>
+                    <td><input id="maxTopicLength" type="checkbox" class="value"/></td>
+                    <td></td>
                 </tr>
                 <tr id="_clientId">
                     <td><label class="translate" for="clientId">Client ID:</label></td>

--- a/admin/index.html
+++ b/admin/index.html
@@ -358,8 +358,8 @@
                 </tr>
                 <tr>
                     <td><label class="translate" for="maxTopicLength">Max topic length:</label></td>
-                    <td><input id="maxTopicLength" type="checkbox" class="value"/></td>
-                    <td></td>
+                    <td><input id="maxTopicLength" class="value" size="17"/></td>
+                    <td class="translate">chars</td>
                 </tr>
                 <tr id="_clientId">
                     <td><label class="translate" for="clientId">Client ID:</label></td>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -148,6 +148,7 @@
         settings.retransmitInterval = settings.retransmitInterval || 2000;
         settings.retransmitCount = settings.retransmitCount || 10;
         settings.sendAckToo = settings.sendAckToo || false;
+        settings.sendStateObject = settings.sendStateObject || false;
         settings.webSocket  = settings.webSocket  || false;
         settings.defaultQoS = (settings.defaultQoS === '' || settings.defaultQoS === -1 || settings.defaultQoS === '-1') ? -1 : settings.defaultQoS || 0;
         if (settings.sendOnStartInterval === undefined) settings.sendOnStartInterval = 2000;
@@ -383,6 +384,10 @@
                     <div class="input-field col s12 m6 l3">
                         <input id="extraSet" type="checkbox" class="value filled-in" />
                         <span class="translate" for="extraSet">Use different topic names for set and get:</span>
+                    </div>
+                    <div class="input-field col s12 m6 l3">
+                        <input id="sendStateObject" type="checkbox" class="value filled-in" />
+                        <span class="translate" for="sendStateObject">Send state object as mqtt message</span>
                     </div>
                 </div>
                 <div class="row">

--- a/io-package.json
+++ b/io-package.json
@@ -147,6 +147,7 @@
         "prefix": "",
         "forceCleanSession": "no",
         "sendAckToo": false,
+        "sendStateObject": true,
         "webSocket": false,
         "maxTopicLength": 100,
         "publishOnSubscribe": true,

--- a/io-package.json
+++ b/io-package.json
@@ -147,7 +147,7 @@
         "prefix": "",
         "forceCleanSession": "no",
         "sendAckToo": false,
-        "sendStateObject": true,
+        "sendStateObject": false,
         "webSocket": false,
         "maxTopicLength": 100,
         "publishOnSubscribe": true,

--- a/lib/client.js
+++ b/lib/client.js
@@ -57,7 +57,7 @@ function MQTTClient(adapter, states) {
 
         publishMessage(
             adapter.config.extraSet && state && !state.ack ? topic + '/set' : topic,
-            state ? state2string(state) : null
+            state ? state : null
         );
 
         if (cb) cb(id);
@@ -71,7 +71,7 @@ function MQTTClient(adapter, states) {
             adapter.log.debug('Send to server "' + adapter.config.prefix + topic + '": ' + message);
         }
 
-        client.publish(topic, message, {qos: adapter.config.defaultQoS, retain: adapter.config.retain});
+        client.publish(topic, state2string(message, adapter.config.sendStateObject), {qos: adapter.config.defaultQoS, retain: adapter.config.retain});
     }
 
     function publishAllStates(config, toPublish) {
@@ -101,13 +101,13 @@ function MQTTClient(adapter, states) {
         toPublish.shift();
 
         if (adapter.config.extraSet && states[id] && !states[id].ack) {
-            client.publish(id2topic[id] + '/set', state2string(states[id]), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
+            client.publish(id2topic[id] + '/set', state2string(states[id], adapter.config.sendStateObject), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
                 if (err) adapter.log.error('client.publish2: ' + err);
                 setImmediate(() => publishAllStates(config, toPublish));
             });
         } else {
             if (states[id]) {
-                client.publish(id2topic[id], state2string(states[id]), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
+                client.publish(id2topic[id], state2string(states[id], adapter.config.sendStateObject), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
                     if (err) adapter.log.error('client.publish: ' + err);
                     setImmediate(() => publishAllStates(config, toPublish));
                 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -57,7 +57,7 @@ function MQTTClient(adapter, states) {
 
         publishMessage(
             adapter.config.extraSet && state && !state.ack ? topic + '/set' : topic,
-            state ? state2string(state.val) : null
+            state ? state2string(state) : null
         );
 
         if (cb) cb(id);
@@ -101,13 +101,13 @@ function MQTTClient(adapter, states) {
         toPublish.shift();
 
         if (adapter.config.extraSet && states[id] && !states[id].ack) {
-            client.publish(id2topic[id] + '/set', state2string(states[id].val), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
+            client.publish(id2topic[id] + '/set', state2string(states[id]), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
                 if (err) adapter.log.error('client.publish2: ' + err);
                 setImmediate(() => publishAllStates(config, toPublish));
             });
         } else {
             if (states[id]) {
-                client.publish(id2topic[id], state2string(states[id].val), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
+                client.publish(id2topic[id], state2string(states[id]), {qos: adapter.config.defaultQoS, retain: adapter.config.retain}, err => {
                     if (err) adapter.log.error('client.publish: ' + err);
                     setImmediate(() => publishAllStates(config, toPublish));
                 });

--- a/lib/common.js
+++ b/lib/common.js
@@ -23,12 +23,10 @@ function state2string(val, sendStateObject) {
     if(typeof sendStateObject === 'undefined' || sendStateObject === null) sendStateObject = false;
 
     if (val && typeof val === 'object') {
-        if (val.ack === undefined && val.val !== undefined) {
-            if (val.val === null) return 'null';
-            return (sendStateObject === true) ? JSON.stringify(val) : val.val.toString();
-        } else {
-            return JSON.stringify(val);
+        if (val.val === null) {
+            return 'null';
         }
+        return (sendStateObject === true) ? JSON.stringify(val) : val.val.toString();
     } else {
         return (val === null) ? 'null' : (val === undefined ? 'undefined' : (sendStateObject === true) ? JSON.stringify(val) : val.toString());
     }

--- a/lib/common.js
+++ b/lib/common.js
@@ -25,12 +25,12 @@ function state2string(val, sendStateObject) {
     if (val && typeof val === 'object') {
         if (val.ack === undefined && val.val !== undefined) {
             if (val.val === null) return 'null';
-            return (sendStateObject) ? JSON.stringify(val) : val.val.toString();
+            return (sendStateObject === true) ? JSON.stringify(val) : val.val.toString();
         } else {
             return JSON.stringify(val);
         }
     } else {
-        return (val === null) ? 'null' : (val === undefined ? 'undefined' : (sendStateObject) ? JSON.stringify(val) : val.toString());
+        return (val === null) ? 'null' : (val === undefined ? 'undefined' : (sendStateObject === true) ? JSON.stringify(val) : val.toString());
     }
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -18,16 +18,19 @@ function convertID2topic(id, pattern, prefix, namespace) {
     return topic;
 }
 
-function state2string(val) {
+function state2string(val, sendStateObject) {
+
+    if(typeof sendStateObject === 'undefined' || sendStateObject === null) sendStateObject = false;
+
     if (val && typeof val === 'object') {
         if (val.ack === undefined && val.val !== undefined) {
             if (val.val === null) return 'null';
-            return val.val.toString();
+            return (sendStateObject) ? JSON.stringify(val) : val.val.toString();
         } else {
             return JSON.stringify(val);
         }
     } else {
-        return (val === null) ? 'null' : (val === undefined ? 'undefined' : val.toString());
+        return (val === null) ? 'null' : (val === undefined ? 'undefined' : (sendStateObject) ? JSON.stringify(val) : val.toString());
     }
 }
 


### PR DESCRIPTION
Hi,

added the option to send the client messages as parsed string JSON objects to the broker. 

The default implementation sends only the values ```states.val```. I do want to have the complete state object with the parameters ```ack```, ```ts```, and so on.