### PR TITLE
Insert an option to not validate the certificate in the client using SSL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
   - package-ecosystem: npm
     directory: "/"
     schedule:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 15.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 15.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ admin/i18n/flat.txt
 admin/i18n/*/flat.txt
 iob_npm.done
 package-lock.json
+.vs/

--- a/admin/index.html
+++ b/admin/index.html
@@ -262,7 +262,10 @@
                 </tr>
                 <tr>
                     <td><label class="translate" for="ssl">Secure:</label></td>
-                    <td><input id="ssl" type="checkbox" class="value"/></td>
+                    <td><input id="ssl" type="checkbox" class="value" /></td>
+                    <td></td>
+                    <td><label class="translate" for="rejectUnauthorized">rejectUnauthorized</label></td>
+                    <td><input id="rejectUnauthorized" type="checkbox" class="value" /></td>
                     <td></td>
                 </tr>
                 <tr id="_certPublic">

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -304,6 +304,10 @@
                         <input id="ssl" type="checkbox" class="value filled-in" />
                         <span class="translate" for="ssl">Secure:</span>
                     </div>
+                    <div class="input-field col s12 m12">
+                        <input id="rejectUnauthorized" type="checkbox" class="value filled-in" />
+                        <span class="translate" for="rejectUnauthorized">rejectUnauthorized</span>
+                    </div>
                     <div class="input-field col s12 m6 l4" id="_certPublic">
                         <select id="certPublic" class="value"></select>
                         <label class="translate" for="certPublic">Public certificate:</label>

--- a/lib/client.js
+++ b/lib/client.js
@@ -134,7 +134,8 @@ function MQTTClient(adapter, states) {
                 protocolVersion: 4,
                 reconnectPeriod: config.reconnectPeriod || 1000, /* in milliseconds */
                 connectTimeout: (config.connectTimeout || 30) * 1000, /* in milliseconds */
-                clean: !config.persistent
+                clean: !config.persistent,
+                rejectUnauthorized: config.rejectUnauthorized /* added option to disable certification validation */
             });
         } catch (err) {
             adapter.log.error('Can not connect to mqtt server: ' + err);


### PR DESCRIPTION
My intension was to connect my Hisense-TV to ioBroker.
Therefore I used the following knowledge bases:
https://github.com/mqttjs/MQTT.js
https://github.com/Krazy998/mqtt-hisensetv/blob/master/README.md

The brake through was to disable the validation of the certificate of the TV. This needs just an additional option in the MQTT-client, which I have added.