### PR TITLE
wildcard regex for `/#`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -465,9 +465,11 @@ function MQTTServer(adapter, states) {
             if (pattern[0] !== '*' && pattern[pattern.length - 1] === '*') pattern = '^' + pattern;
             if (pattern[0] === '+') pattern = '^[^.]*' + pattern.substring(1);
             if (pattern[pattern.length - 1] === '+') pattern = pattern.substring(0, pattern.length - 1) + '[^.]*$';
+        } else {
+            return (pattern = '.*');
         }
         pattern = pattern.replace(/\./g, '\\.');
-        pattern = pattern.replace(/\*/g, '.*');
+        pattern = pattern.replace(/\\\.\*/g, '(\\..*)?');
         pattern = pattern.replace(/\+/g, '[^.]*');
         return pattern;
     }


### PR DESCRIPTION
As mentioned in #220 this is a small fix. 
This matches a subscribe to `abc/#` to valid `abc`, `abc/def`, `abc/def/ghi`, etc., but does not check for invalid subscritions. 