### PR TITLE
Optimize handling of ignoreTopics ending with ","

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -26,14 +26,17 @@ function MQTTClient(adapter, states) {
     const verifiedObjects = {};
 
     const ignoredTopicsRegexes = [];
-    if(adapter.config.ignoredTopics) {
-        const ignoredTopics = adapter.config.ignoredTopics.split(',');
-        for (const ignoredTopicPattern of ignoredTopics) {
-            const ignoredTopicRegexWithNameSpace = pattern2RegEx(`${adapter.namespace}.${ignoredTopicPattern}`, adapter);
-            const ignoredTopicRegex = pattern2RegEx(ignoredTopicPattern, adapter);
-            adapter.log.info(`Ignoring topic with pattern: ${ignoredTopicPattern} (RegExp: ${ignoredTopicRegex} und ${ignoredTopicRegexWithNameSpace})`);
-            ignoredTopicsRegexes.push(new RegExp(ignoredTopicRegex), new RegExp(ignoredTopicRegexWithNameSpace));
+    const ignoredTopics = adapter.config.ignoredTopics?.split(',') ?? [];
+    for (const ignoredTopicPattern of ignoredTopics) {
+        if(!ignoredTopicPattern) {
+            // Empty strings would filter out all topics, which is probably not what the user wants
+            ignoredTopics.length > 1 && adapter.log.warn(`Ignored topics should not end with an ",".`);
+            continue;
         }
+        const ignoredTopicRegexWithNameSpace = pattern2RegEx(`${adapter.namespace}.${ignoredTopicPattern}`, adapter);
+        const ignoredTopicRegex = pattern2RegEx(ignoredTopicPattern, adapter);
+        adapter.log.info(`Ignoring topic with pattern: ${ignoredTopicPattern} (RegExp: ${ignoredTopicRegex} und ${ignoredTopicRegexWithNameSpace})`);
+        ignoredTopicsRegexes.push(new RegExp(ignoredTopicRegex), new RegExp(ignoredTopicRegexWithNameSpace));
     }
 
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,15 +36,19 @@ function MQTTServer(adapter, states) {
     const verifiedObjects = {};
 
     const ignoredTopicsRegexes = [];
-    if(adapter.config.ignoredTopics) {
-        const ignoredTopics = adapter.config.ignoredTopics.split(',');
-        for (const ignoredTopicPattern of ignoredTopics) {
-            const ignoredTopicRegexWithNameSpace = pattern2RegEx(`${adapter.namespace}.${ignoredTopicPattern}`, adapter);
-            const ignoredTopicRegex = pattern2RegEx(ignoredTopicPattern, adapter);
-            adapter.log.info(`Ignoring topic with pattern: ${ignoredTopicPattern} (RegExp: ${ignoredTopicRegex} und ${ignoredTopicRegexWithNameSpace})`);
-            ignoredTopicsRegexes.push(new RegExp(ignoredTopicRegex), new RegExp(ignoredTopicRegexWithNameSpace));
+    const ignoredTopics = adapter.config.ignoredTopics?.split(',') ?? [];
+    for (const ignoredTopicPattern of ignoredTopics) {
+        if(!ignoredTopicPattern) {
+            // Empty strings would filter out all topics, which is probably not what the user wants
+            ignoredTopics.length > 1 && adapter.log.warn(`Ignored topics should not end with an ",".`);
+            continue;
         }
+        const ignoredTopicRegexWithNameSpace = pattern2RegEx(`${adapter.namespace}.${ignoredTopicPattern}`, adapter);
+        const ignoredTopicRegex = pattern2RegEx(ignoredTopicPattern, adapter);
+        adapter.log.info(`Ignoring topic with pattern: ${ignoredTopicPattern} (RegExp: ${ignoredTopicRegex} und ${ignoredTopicRegexWithNameSpace})`);
+        ignoredTopicsRegexes.push(new RegExp(ignoredTopicRegex), new RegExp(ignoredTopicRegexWithNameSpace));
     }
+
 
     adapter.config.sendOnStartInterval = parseInt(adapter.config.sendOnStartInterval, 10) || 2000;
     adapter.config.sendInterval        = parseInt(adapter.config.sendInterval,        10) || 0;


### PR DESCRIPTION
This improves usability around `ignoreTopics` slighty as a faulty input could result in all topics being filtered as discussed with @Apollon77 