### PR TITLE
fix: send PUBREL for unknown messageId to resolve QoS 2 session lockup

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1049,8 +1049,18 @@ function MQTTServer(adapter, states) {
                     client.pubrel({ messageId: packet.messageId });
                 } else {
                     adapter.log.info(
-                        `Client [${client.id}] Received pubrec on ${client.id} for unknown messageId ${packet.messageId}`,
+                        `Client [${client.id}] Received pubrec on ${client.id} for unknown messageId ${packet.messageId} - sending pubrel anyway to complete handshake`,
                     );
+                    // Send PUBREL anyway to allow the client to complete the QoS 2 handshake.
+                    // Without this, devices with hardcoded QoS 2 get stuck in an
+                    // infinite PUBREC loop that blocks the entire MQTT session.
+                    try {
+                        client.pubrel({ messageId: packet.messageId });
+                    } catch (e) {
+                        adapter.log.warn(
+                            `Client [${client.id}] Cannot send pubrel for unknown messageId ${packet.messageId}: ${e}`,
+                        );
+                    }
                 }
             });
 

--- a/test/testSimServer.js
+++ b/test/testSimServer.js
@@ -304,3 +304,125 @@ describe('MQTT server', function () {
         server.destroy(done);
     });
 });
+
+/**
+ * Regression test for the QoS 2 session lockup fix.
+ *
+ * Scenario being tested:
+ *   1. The broker publishes a QoS 2 message to a subscribed client.
+ *   2. The client never responds with PUBREC, so the broker retransmits the message.
+ *   3. Eventually the broker exceeds its retransmit count and deletes the message
+ *      from its outgoing queue (client._messages).
+ *   4. The client then sends a late PUBREC for the deleted messageId.
+ *   5. The broker must respond with PUBREL to complete the handshake (the fix).
+ *      Without the fix the broker would silently drop the PUBREC, leaving the client
+ *      stuck in an infinite PUBREC loop.
+ *
+ * A dedicated server instance is used with very short retransmit settings so the
+ * message is purged after ≈200 ms, keeping the test fast.
+ */
+describe('MQTT server: QoS2 session lockup regression', function () {
+    let adapter2;
+    let server2;
+    const states2 = {};
+
+    before('MQTT server: QoS2 lockup: Start server', done => {
+        adapter2 = new Adapter({
+            port: ++port,
+            defaultQoS: 2,
+            onchange: true,
+            // Very short retransmit settings so the message is purged after ~200 ms:
+            // First tick (100 ms): count=0, not yet exceeded → resend, count becomes 1
+            // Second tick (100 ms): count=1 > retransmitCount=0 → delete
+            retransmitInterval: 100,
+            retransmitCount: 0,
+        });
+        server2 = new Server(adapter2, states2);
+        // Give the TCP server a chance to start listening before the tests run
+        setTimeout(done, 100);
+    });
+
+    it('MQTT server: QoS2 lockup: Broker sends PUBREL for orphaned PUBREC messageId', done => {
+        const net = require('net');
+        const mqttCon = require('mqtt-connection');
+        const stream = net.createConnection(port, '127.0.0.1');
+        const client = mqttCon(stream);
+
+        let capturedMessageId = null;
+        let firstPublishSeen = false;
+
+        stream.on('error', err => {
+            // Only fail the test if it hasn't already passed
+            if (capturedMessageId === null) {
+                done(err);
+            }
+        });
+
+        // Step 1 – Connected: subscribe to the test topic with QoS 2
+        client.on('connack', () => {
+            client.subscribe({
+                subscriptions: [{ topic: 'qos2orphan', qos: 2 }],
+                messageId: 1,
+            });
+        });
+
+        // Step 2 – Subscribed: trigger the broker to publish a QoS 2 message
+        client.on('suback', async () => {
+            // Ensure the object exists before calling onStateChange so that
+            // getMqttMessage can resolve the id → topic mapping.
+            await adapter2.setForeignObjectAsync('mqtt.0.qos2orphan', {
+                _id: 'mqtt.0.qos2orphan',
+                type: 'state',
+                common: { type: 'string', name: 'qos2orphan', role: 'variable', read: true, write: true },
+                native: {},
+            });
+            states2['mqtt.0.qos2orphan'] = { val: 'testPayload', ack: false };
+            server2.onStateChange('mqtt.0.qos2orphan', { val: 'testPayload', ack: false });
+        });
+
+        // Step 3 – PUBLISH received: capture messageId but intentionally withhold PUBREC
+        //          so that the broker retransmits and eventually purges the message.
+        client.on('publish', packet => {
+            if (!firstPublishSeen && packet.qos === 2) {
+                firstPublishSeen = true;
+                capturedMessageId = packet.messageId;
+
+                // Wait long enough (400 ms > 2 × 100 ms retransmit interval) for the
+                // broker to retransmit once and then delete the message from _messages.
+                setTimeout(() => {
+                    expect(capturedMessageId).to.be.a('number');
+                    // Send PUBREC for the now-deleted messageId (the "orphaned" PUBREC)
+                    client.pubrec({ messageId: capturedMessageId });
+                }, 400);
+            }
+            // Ignore any retransmitted PUBLISH packets
+        });
+
+        // Step 4 – PUBREL received: the broker must send PUBREL for the unknown messageId
+        //          (this is the behaviour introduced by the fix)
+        client.on('pubrel', packet => {
+            if (packet.messageId === capturedMessageId) {
+                // Complete the handshake from the client side
+                client.pubcomp({ messageId: packet.messageId });
+                // Give pubcomp a moment to be flushed before tearing down the stream
+                setTimeout(() => {
+                    stream.destroy();
+                    done();
+                }, 50);
+            }
+        });
+
+        // Initiate the MQTT connection
+        client.connect({
+            clientId: 'qos2OrphanRegression',
+            clean: true,
+            keepalive: 0,
+            protocolId: 'MQTT',
+            protocolVersion: 4,
+        });
+    }).timeout(5000);
+
+    after('MQTT server: QoS2 lockup: Stop server', done => {
+        server2.destroy(done);
+    });
+});


### PR DESCRIPTION
When a MQTT client sends a PUBREC for a messageId that the broker no longer has in its internal message queue (e.g. after the message was deleted due to exceeding the retry limit), the broker now responds with PUBREL anyway to allow the client to complete the QoS 2 handshake.

Previously, the broker only logged "unknown messageId" and did nothing, leaving the client stuck in an infinite PUBREC retransmission loop that blocked the entire MQTT session until adapter restart.

The new behavior is compliant with the MQTT specification.

https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html (4.3.3 QoS 2: Exactly once delivery)

Fixes https://github.com/ioBroker/ioBroker.mqtt/issues/449