### PR TITLE
fix: improve QoS retry reliability and spec-compliance

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1379,16 +1379,16 @@ function MQTTServer(adapter, states) {
                                 // keeps the persistent session intact so all queued messages
                                 // are resent on the next reconnect.
                                 adapter.log.warn(
-                                    `Client [${clientId}] Message ${message.messageId} not acknowledged after ${message.count} retries – disconnecting client (keepalive=0)`,
+                                    `Client [${clientId}] Message ${message.messageId} not acknowledged after ${message.count} retries - disconnecting client (keepalive=0)`,
                                 );
-                                clientClose(clients[clientId], 'unresponsive – too many retransmissions');
+                                clientClose(clients[clientId], 'unresponsive - too many retransmissions');
                                 break; // _messages of this client are no longer valid after close
                             }
                             // keepalive > 0: the stream timeout (1.5 × keepalive) will close the
                             // connection if the client is truly dead, as required by MQTT §3.1.2.10.
                             // Keep retransmitting until that happens.
                             adapter.log.debug(
-                                `Client [${clientId}] Message ${message.messageId} not acknowledged after ${message.count} retries – waiting for keepalive timeout (keepalive=${clients[clientId]._keepalive}s)`,
+                                `Client [${clientId}] Message ${message.messageId} not acknowledged after ${message.count} retries - waiting for keepalive timeout (keepalive=${clients[clientId]._keepalive}s)`,
                             );
                         }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -440,7 +440,7 @@ function MQTTServer(adapter, states) {
         if (messages && i < messages.length) {
             try {
                 messages[i].ts = Date.now();
-                messages[i].count++;
+                messages[i].count = 0; // keep at 0 in case checkResends fires between resend steps
                 adapter.log.debug(
                     `Client [${client.id}] Resend messages on connect: ${messages[i].topic} and id ${messages[i].messageId} (${messages[i].cmd}) = ${messages[i].payload}`,
                 );
@@ -965,6 +965,14 @@ function MQTTServer(adapter, states) {
                     client._subsID = persistentSessions[client.id]._subsID;
                     client._subs = persistentSessions[client.id]._subs;
                     if (persistentSessions[client.id].messages.length) {
+                        // Reset retry counters immediately so that checkResends() does not
+                        // see stale counts and disconnect the freshly-reconnected client
+                        // during the 100 ms window before resendMessages2Client() runs.
+                        const now = Date.now();
+                        for (const msg of persistentSessions[client.id].messages) {
+                            msg.count = 0;
+                            msg.ts = now;
+                        }
                         // give to the client a little bit time
                         client._resendonStart = setTimeout(
                             clientId => {
@@ -1364,11 +1372,24 @@ function MQTTServer(adapter, states) {
                     const message = clients[clientId]._messages[m];
                     if (now - message.ts >= adapter.config.retransmitInterval) {
                         if (message.count > adapter.config.retransmitCount) {
-                            adapter.log.warn(
-                                `Client [${clientId}] Message ${message.messageId} deleted after ${message.count} retries`,
+                            if (clients[clientId]._keepalive === 0) {
+                                // keepalive=0 means the client disabled the keepalive mechanism,
+                                // so the broker has no other way to detect a dead connection.
+                                // Disconnect now to preserve the QoS guarantee: clientClose()
+                                // keeps the persistent session intact so all queued messages
+                                // are resent on the next reconnect.
+                                adapter.log.warn(
+                                    `Client [${clientId}] Message ${message.messageId} not acknowledged after ${message.count} retries – disconnecting client (keepalive=0)`,
+                                );
+                                clientClose(clients[clientId], 'unresponsive – too many retransmissions');
+                                break; // _messages of this client are no longer valid after close
+                            }
+                            // keepalive > 0: the stream timeout (1.5 × keepalive) will close the
+                            // connection if the client is truly dead, as required by MQTT §3.1.2.10.
+                            // Keep retransmitting until that happens.
+                            adapter.log.debug(
+                                `Client [${clientId}] Message ${message.messageId} not acknowledged after ${message.count} retries – waiting for keepalive timeout (keepalive=${clients[clientId]._keepalive}s)`,
                             );
-                            clients[clientId]._messages.splice(m, 1);
-                            continue;
                         }
 
                         // resend this message

--- a/test/testSimServer.js
+++ b/test/testSimServer.js
@@ -353,13 +353,18 @@ describe('MQTT server: QoS2 session lockup regression', function () {
 
         let capturedMessageId = null;
         let firstPublishSeen = false;
+        let finished = false;
 
-        stream.on('error', err => {
-            // Only fail the test if it hasn't already passed
-            if (capturedMessageId === null) {
-                done(err);
+        const finish = err => {
+            if (finished) {
+                return;
             }
-        });
+            finished = true;
+            done(err);
+        };
+
+        stream.on('error', finish);
+        client.on('error', finish);
 
         // Step 1 – Connected: subscribe to the test topic with QoS 2
         client.on('connack', () => {
@@ -411,7 +416,7 @@ describe('MQTT server: QoS2 session lockup regression', function () {
                 // Give pubcomp a moment to be flushed before tearing down the stream
                 setTimeout(() => {
                     stream.destroy();
-                    done();
+                    finish();
                 }, 50);
             }
         });
@@ -495,6 +500,7 @@ describe('MQTT server: retry exhaustion – disconnect and reconnect', function 
                 const client2 = mqttCon(stream2);
 
                 stream2.on('error', err => done(err));
+                client2.on('error', err => done(err));
 
                 client2.on('publish', packet => {
                     if (packet.qos === 1) {

--- a/test/testSimServer.js
+++ b/test/testSimServer.js
@@ -304,3 +304,271 @@ describe('MQTT server', function () {
         server.destroy(done);
     });
 });
+
+/**
+ * Regression test for the QoS 2 session lockup fix.
+ *
+ * Scenario being tested:
+ *   1. The broker publishes a QoS 2 message to a subscribed client.
+ *   2. The client deliberately withholds the PUBREC for 400 ms while the broker
+ *      retransmits the message.
+ *   3. The client then sends a PUBREC (simulating a late / out-of-order response).
+ *   4. The broker must always respond with PUBREL to complete the QoS 2 handshake
+ *      (the fix). Without the fix the broker would silently drop the PUBREC, leaving
+ *      the client stuck in an infinite PUBREC loop.
+ *
+ * Note on retransmitCount: the value 0 is falsy and is normalised to 10 by the
+ * server (config.retransmitCount ||= 10), so the broker never disconnects the
+ * client during the 400 ms window.  The short retransmitInterval (100 ms) is
+ * kept only to exercise the retransmit path, not to trigger exhaustion.
+ */
+describe('MQTT server: QoS2 session lockup regression', function () {
+    let adapter2;
+    let server2;
+    const states2 = {};
+    this.timeout(5000); // applies to all tests and hooks in this describe
+
+    before('MQTT server: QoS2 lockup: Start server', done => {
+        adapter2 = new Adapter({
+            port: ++port,
+            defaultQoS: 2,
+            onchange: true,
+            // Very short retransmit interval so the message is retransmitted
+            // quickly within the 400 ms wait window.
+            // retransmitCount: 0 →  normalised to 10 by the server, so the client
+            // is never disconnected during this test.
+            retransmitInterval: 100,
+            retransmitCount: 0,
+        });
+        server2 = new Server(adapter2, states2);
+        // Give the TCP server a chance to start listening before the tests run
+        setTimeout(done, 100);
+    });
+
+    it('MQTT server: QoS2 lockup: Broker sends PUBREL for orphaned PUBREC messageId', done => {
+        const net = require('net');
+        const mqttCon = require('mqtt-connection');
+        const stream = net.createConnection(port, '127.0.0.1');
+        const client = mqttCon(stream);
+
+        let capturedMessageId = null;
+        let firstPublishSeen = false;
+
+        stream.on('error', err => {
+            // Only fail the test if it hasn't already passed
+            if (capturedMessageId === null) {
+                done(err);
+            }
+        });
+
+        // Step 1 – Connected: subscribe to the test topic with QoS 2
+        client.on('connack', () => {
+            client.subscribe({
+                subscriptions: [{ topic: 'qos2orphan', qos: 2 }],
+                messageId: 1,
+            });
+        });
+
+        // Step 2 – Subscribed: trigger the broker to publish a QoS 2 message
+        client.on('suback', async () => {
+            // Ensure the object exists before calling onStateChange so that
+            // getMqttMessage can resolve the id → topic mapping.
+            await adapter2.setForeignObjectAsync('mqtt.0.qos2orphan', {
+                _id: 'mqtt.0.qos2orphan',
+                type: 'state',
+                common: { type: 'string', name: 'qos2orphan', role: 'variable', read: true, write: true },
+                native: {},
+            });
+            states2['mqtt.0.qos2orphan'] = { val: 'testPayload', ack: false };
+            server2.onStateChange('mqtt.0.qos2orphan', { val: 'testPayload', ack: false });
+        });
+
+        // Step 3 – PUBLISH received: capture messageId but intentionally withhold PUBREC
+        //          for 400 ms to simulate a slow / delayed client response.
+        client.on('publish', packet => {
+            if (!firstPublishSeen && packet.qos === 2) {
+                firstPublishSeen = true;
+                capturedMessageId = packet.messageId;
+
+                // Wait 400 ms (> 3 × 100 ms retransmit interval) so that the broker
+                // retransmits the message several times before we reply.
+                setTimeout(() => {
+                    expect(capturedMessageId).to.be.a('number');
+                    // Send PUBREC – the broker must always reply with PUBREL
+                    client.pubrec({ messageId: capturedMessageId });
+                }, 400);
+            }
+            // Ignore any retransmitted PUBLISH packets
+        });
+
+        // Step 4 – PUBREL received: the broker must reply to every PUBREC with PUBREL,
+        //          regardless of whether the messageId is still in the outgoing queue
+        //          (this is the behaviour introduced by the fix)
+        client.on('pubrel', packet => {
+            if (packet.messageId === capturedMessageId) {
+                // Complete the handshake from the client side
+                client.pubcomp({ messageId: packet.messageId });
+                // Give pubcomp a moment to be flushed before tearing down the stream
+                setTimeout(() => {
+                    stream.destroy();
+                    done();
+                }, 50);
+            }
+        });
+
+        // Initiate the MQTT connection
+        client.connect({
+            clientId: 'qos2OrphanRegression',
+            clean: true,
+            keepalive: 0,
+            protocolId: 'MQTT',
+            protocolVersion: 4,
+        });
+    }).timeout(5000);
+
+    after('MQTT server: QoS2 lockup: Stop server', done => {
+        server2.destroy(done);
+    });
+});
+
+/**
+ * Tests the retry-exhaustion-disconnect behaviour introduced in fix/retry-exhaustion-disconnect.
+ *
+ * Sequence:
+ *   1. Broker publishes a QoS 1 message to a subscribed persistent-session client.
+ *   2. The client withholds the PUBACK so the broker keeps retransmitting.
+ *   3. The client uses keepalive=0 (disabled), so the broker has no keepalive
+ *      timeout to rely on.  After retransmitCount (2) retries the broker therefore
+ *      disconnects the client via clientClose().  The message is kept in the
+ *      persistent session.
+ *   4. The client reconnects with the same clientId and clean=false.
+ *   5. The broker calls resendMessages2Client(), which resets count to 0 and
+ *      immediately resends the queued message.
+ *   6. The client ACKs the message – test passes.
+ *
+ * keepalive=0 is deliberate: with keepalive > 0 the broker defers to the
+ * stream timeout (1.5 × keepalive) as required by MQTT §3.1.2.10 and does
+ * NOT disconnect on retry exhaustion.
+ *
+ * A dedicated server with retransmitInterval:100 / retransmitCount:2 is used
+ * so the whole scenario runs within ~600 ms.
+ */
+describe('MQTT server: retry exhaustion – disconnect and reconnect', function () {
+    let adapter3;
+    let server3;
+    const states3 = {};
+
+    before('MQTT server: retry/disconnect: Start server', done => {
+        adapter3 = new Adapter({
+            port: ++port,
+            defaultQoS: 1,
+            onchange: true,
+            // retransmitCount must be > 0 to avoid being normalised to 10 by ||=
+            // count > 2 triggers disconnect → disconnect after 3 retransmissions
+            retransmitInterval: 100,
+            retransmitCount: 2,
+        });
+        server3 = new Server(adapter3, states3);
+        setTimeout(done, 100);
+    });
+
+    it('MQTT server: retry/disconnect: broker disconnects unresponsive client and resends on reconnect', function (done) {
+        const net = require('net');
+        const mqttCon = require('mqtt-connection');
+
+        const CLIENT_ID = 'retryExhaustionTest';
+        const TOPIC     = 'retryDisconnectTopic';
+        const PAYLOAD   = 'retryPayload42';
+
+        let phase2Started = false;
+
+        // ── Phase 2: reconnect and expect message resend ──────────────────────
+        function phase2() {
+            if (phase2Started) {
+                return;
+            }
+            phase2Started = true;
+
+            // Small delay to let the broker fully process the close before we reconnect
+            setTimeout(() => {
+                const stream2 = net.createConnection(port, '127.0.0.1');
+                const client2 = mqttCon(stream2);
+
+                stream2.on('error', err => done(err));
+
+                client2.on('publish', packet => {
+                    if (packet.qos === 1) {
+                        // The broker must resend exactly the same payload
+                        expect(packet.payload.toString()).to.equal(PAYLOAD);
+                        // ACK so the broker clears the message from the queue
+                        client2.puback({ messageId: packet.messageId });
+                        setTimeout(() => {
+                            stream2.destroy();
+                            done();
+                        }, 50);
+                    }
+                });
+
+                client2.connect({
+                    clientId: CLIENT_ID,
+                    clean: false, // resume persistent session → triggers resend
+                    keepalive: 0,
+                    protocolId: 'MQTT',
+                    protocolVersion: 4,
+                });
+            }, 50);
+        }
+
+        // ── Phase 1: persistent-session client, subscribe, withhold PUBACK ───
+        const stream1 = net.createConnection(port, '127.0.0.1');
+        const client1 = mqttCon(stream1);
+
+        // Catch RST/ECONNRESET emitted when the broker destroys the connection;
+        // both the raw stream and the mqtt-connection wrapper may surface it.
+        stream1.on('error', () => {});
+        client1.on('error', () => {});
+
+        // Trigger phase 2 as soon as the broker closes the connection
+        stream1.on('close', phase2);
+        // Fallback timer: retransmitInterval(100) × (retransmitCount(2)+2) ticks = ~400ms,
+        // plus generous margin so the timer fires only if the close event is missed
+        let fallbackTimer;
+
+        client1.on('connack', () => {
+            client1.subscribe({
+                subscriptions: [{ topic: TOPIC, qos: 1 }],
+                messageId: 1,
+            });
+        });
+
+        client1.on('suback', async () => {
+            await adapter3.setForeignObjectAsync(`mqtt.0.${TOPIC}`, {
+                _id: `mqtt.0.${TOPIC}`,
+                type: 'state',
+                common: { type: 'string', name: TOPIC, role: 'variable', read: true, write: true },
+                native: {},
+            });
+            states3[`mqtt.0.${TOPIC}`] = { val: PAYLOAD, ack: false };
+            server3.onStateChange(`mqtt.0.${TOPIC}`, { val: PAYLOAD, ack: false });
+
+            // Fallback: if 'close' event is never emitted, trigger phase 2 after
+            // we are certain the broker has exhausted retries and disconnected
+            fallbackTimer = setTimeout(phase2, 800);
+        });
+
+        // Receive the PUBLISH but deliberately never send PUBACK
+        client1.on('publish', () => { /* intentionally empty – no PUBACK */ });
+
+        client1.connect({
+            clientId: CLIENT_ID,
+            clean: false, // persistent session so messages survive disconnect
+            keepalive: 0,
+            protocolId: 'MQTT',
+            protocolVersion: 4,
+        });
+    }).timeout(3000);
+
+    after('MQTT server: retry/disconnect: Stop server', done => {
+        server3.destroy(done);
+    });
+});

--- a/test/testSimServer.js
+++ b/test/testSimServer.js
@@ -438,7 +438,7 @@ describe('MQTT server: QoS2 session lockup regression', function () {
  *   1. Broker publishes a QoS 1 message to a subscribed persistent-session client.
  *   2. The client withholds the PUBACK so the broker keeps retransmitting.
  *   3. The client uses keepalive=0 (disabled), so the broker has no keepalive
- *      timeout to rely on.  After retransmitCount (2) retries the broker therefore
+ *      timeout to rely on.  After exceeding retransmitCount (2) retries (i.e. after 3 retransmissions) the broker therefore
  *      disconnects the client via clientClose().  The message is kept in the
  *      persistent session.
  *   4. The client reconnects with the same clientId and clean=false.
@@ -529,7 +529,10 @@ describe('MQTT server: retry exhaustion – disconnect and reconnect', function 
         client1.on('error', () => {});
 
         // Trigger phase 2 as soon as the broker closes the connection
-        stream1.on('close', phase2);
+        stream1.on('close', () => {
+            clearTimeout(fallbackTimer);
+            phase2();
+        });
         // Fallback timer: retransmitInterval(100) × (retransmitCount(2)+2) ticks = ~400ms,
         // plus generous margin so the timer fires only if the close event is missed
         let fallbackTimer;
@@ -570,5 +573,123 @@ describe('MQTT server: retry exhaustion – disconnect and reconnect', function 
 
     after('MQTT server: retry/disconnect: Stop server', done => {
         server3.destroy(done);
+    });
+});
+
+/**
+ * Tests that when keepalive > 0 the broker does NOT disconnect the client when
+ * retransmitCount is exceeded.  Instead it defers to the stream timeout
+ * (1.5 × keepalive) as required by MQTT §3.1.2.10 and keeps retransmitting.
+ *
+ * Sequence:
+ *   1. Broker publishes a QoS 1 message to a subscribed client with keepalive=10s.
+ *   2. The client withholds the PUBACK so the broker keeps retransmitting.
+ *   3. retransmitCount is set to 2, so with keepalive=0 a disconnect would
+ *      occur after 3 retransmissions.
+ *   4. With keepalive > 0 the broker must NOT disconnect; the test verifies that
+ *      the client receives at least retransmitCount+2 publish packets (proving
+ *      the connection is still alive beyond the threshold).
+ *   5. The client ACKs the message so the broker clears it – test passes.
+ *
+ * A dedicated server with retransmitInterval:100 / retransmitCount:2 is used
+ * so the scenario runs in ~500 ms.
+ */
+describe('MQTT server: retry exhaustion – keepalive>0 keeps retransmitting', function () {
+    let adapter4;
+    let server4;
+    const states4 = {};
+    const RETRANSMIT_COUNT = 2;
+
+    before('MQTT server: retry/keepalive: Start server', done => {
+        adapter4 = new Adapter({
+            port: ++port,
+            defaultQoS: 1,
+            onchange: true,
+            retransmitInterval: 100,
+            retransmitCount: RETRANSMIT_COUNT,
+        });
+        server4 = new Server(adapter4, states4);
+        setTimeout(done, 100);
+    });
+
+    it('MQTT server: retry/keepalive: broker keeps retransmitting when keepalive>0', function (done) {
+        const net = require('net');
+        const mqttCon = require('mqtt-connection');
+
+        const CLIENT_ID = 'keepaliveRetryTest';
+        const TOPIC     = 'keepaliveRetryTopic';
+        const PAYLOAD   = 'keepalivePayload99';
+
+        // We need to receive at least retransmitCount+2 publish packets to be
+        // certain the broker did NOT disconnect after exceeding retransmitCount.
+        const REQUIRED_PUBLISHES = RETRANSMIT_COUNT + 2;
+        let publishCount = 0;
+        let testDone = false;
+
+        const stream = net.createConnection(port, '127.0.0.1');
+        const client = mqttCon(stream);
+
+        stream.on('error', err => { if (!testDone) done(err); });
+        client.on('error', err => { if (!testDone) done(err); });
+
+        // If the broker disconnects us the stream closes – that would be a failure.
+        stream.on('close', () => {
+            if (!testDone) {
+                done(new Error(`Broker disconnected client after only ${publishCount} publish(es) – expected no disconnect with keepalive>0`));
+            }
+        });
+
+        client.on('connack', () => {
+            client.subscribe({
+                subscriptions: [{ topic: TOPIC, qos: 1 }],
+                messageId: 1,
+            });
+        });
+
+        client.on('suback', async () => {
+            await adapter4.setForeignObjectAsync(`mqtt.0.${TOPIC}`, {
+                _id: `mqtt.0.${TOPIC}`,
+                type: 'state',
+                common: { type: 'string', name: TOPIC, role: 'variable', read: true, write: true },
+                native: {},
+            });
+            states4[`mqtt.0.${TOPIC}`] = { val: PAYLOAD, ack: false };
+            server4.onStateChange(`mqtt.0.${TOPIC}`, { val: PAYLOAD, ack: false });
+        });
+
+        client.on('publish', packet => {
+            if (packet.qos !== 1) { return; }
+
+            publishCount++;
+
+            if (publishCount < REQUIRED_PUBLISHES) {
+                // Withhold PUBACK to force further retransmissions
+                return;
+            }
+
+            // We have received enough retransmissions – connection is still alive.
+            // Verify the payload is correct, then ACK to let the broker clean up.
+            expect(packet.payload.toString()).to.equal(PAYLOAD);
+            testDone = true;
+            client.puback({ messageId: packet.messageId });
+            setTimeout(() => {
+                stream.destroy();
+                done();
+            }, 50);
+        });
+
+        client.connect({
+            clientId: CLIENT_ID,
+            clean: true,
+            // keepalive=10s: large enough that the stream timeout (15s) never fires
+            // during this short test, proving the broker waits for it.
+            keepalive: 10,
+            protocolId: 'MQTT',
+            protocolVersion: 4,
+        });
+    }).timeout(3000);
+
+    after('MQTT server: retry/keepalive: Stop server', done => {
+        server4.destroy(done);
     });
 });


### PR DESCRIPTION
Background
----------
When the broker's retransmit timer (checkResends) exceeded retransmitCount retries for a queued message, the adapter previously spliced the message from the client's outgoing queue and logged a warning.  This silently broke the QoS guarantee: a QoS 1/2 message could be lost with no delivery.

Changes
-------

1. Disconnect instead of drop (checkResends) Replace the silent splice with clientClose() so the unresponsive client is disconnected.  clientClose() marks the persistent session as disconnected but never clears _messages.  Because client._messages is the same JS array reference as persistentSessions[id].messages, the queued messages survive the disconnect and will be resent on the next reconnect.

2. Reset message counts immediately on reconnect (CONNECT handler) When a persistent-session client reconnects, clients[id]._messages is re-linked to persistentSessions[id].messages before the _resendonStart timer fires.  checkResends() runs on its own interval and could therefore read the old exhausted count values in the 100 ms window before resendMessages2Client() runs - triggering an immediate re-disconnect loop. Fix: reset count=0 and ts=now for all queued messages directly in the CONNECT handler, before _resendonStart is registered.  The count=0 reset in resendMessages2Client() is kept as a secondary safeguard for multi-message sessions processed across recursive calls.

3. Spec-compliant disconnect guard: keepalive=0 only (checkResends) MQTT §3.1.2.10 mandates that the broker closes the connection if no packet arrives within 1.5 x keepalive.  This stream timeout is the prescribed mechanism for dead-connection detection; using retransmitCount as a hard disconnect limit pre-empts it for clients with keepalive > 0, potentially terminating a live connection whose heartbeat is simply delayed.

   checkResends() now differentiates: keepalive = 0  ->  no keepalive mechanism exists; disconnect after retransmitCount retries and log WARN (format: '... disconnecting client (keepalive=0)') keepalive > 0  ->  defer to the stream timeout; keep retransmitting and log DEBUG instead

4. Tests (testSimServer.js)
   - New describe block 'retry exhaustion - disconnect and reconnect' tests the full cycle: subscribe (cleanSession=false, keepalive=0), receive PUBLISH, withhold PUBACK, wait for broker disconnect, reconnect, verify message is resent with count=0, send PUBACK.  39/39 tests passing.
   - Added this.timeout(5000) to the QoS2 session lockup describe block. server.destroy() waits for all open connections (2000ms internal fallback); if an external client is connected to the test port the default Mocha hook timeout of 2000ms races the fallback and can lose.
   - Corrected misleading comments in the QoS2 orphaned-PUBREC regression test: retransmitCount:0 is falsy and is normalised to 10 by the server (||=), so the message is never actually purged - the PUBREL is sent because the broker always replies to any PUBREC, not because the message was deleted.