### PR TITLE
fix: correct object type detection for JSON MQTT topics

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -473,13 +473,30 @@ function MQTTClient(adapter, states) {
                     const originalMessage = message;
                     message = convertMessage(topic, message, adapter);
 
-                    const messageType = typeof message;
+                    // For ioBroker state format messages derive the type from the val property.
+                    // - val present and non-null: use typeof val
+                    // - val present but null: type is indeterminate, use 'mixed' (consistent with new-object path)
+                    // - not an ioBroker state object: use typeof message
+                    const messageType =
+                        typeof message === 'object' && message !== null && message.val !== undefined
+                            ? message.val !== null
+                                ? typeof message.val
+                                : 'mixed'
+                            : typeof message;
 
                     if (obj.common.type === null) {
                         obj.common.type = messageType;
                         // New object which is not "file", we create it now that we know the type
-                        if (obj.common.type === 'object' && topic2id[topic].message.val !== undefined) {
-                            obj.common.type = typeof topic2id[topic].message.val;
+                        if (obj.common.type === 'object') {
+                            if (message.val !== undefined && message.val !== null) {
+                                obj.common.type = typeof message.val;
+                            } else {
+                                // val is null/absent: type cannot be determined, use mixed
+                                obj.common.type = 'mixed';
+                            }
+                        } else if (obj.common.type === 'string' && message[0] === '{') {
+                            // JSON payload stored as string (has non-state properties like "event")
+                            obj.common.type = 'mixed';
                         }
                         adapter.log.debug(`Create object for topic: ${topic}[ID: ${obj._id}]`);
                         await adapter.setForeignObjectAsync(obj._id, obj);

--- a/lib/server.js
+++ b/lib/server.js
@@ -474,8 +474,16 @@ function MQTTServer(adapter, states) {
             return;
         }
 
-        // expand an old version of objects
-        const messageType = typeof message;
+        // For ioBroker state format messages derive the type from the val property.
+        // - val present and non-null: use typeof val
+        // - val present but null: type is indeterminate, use 'mixed' (consistent with new-object path)
+        // - not an ioBroker state object: use typeof message
+        const messageType =
+            typeof message === 'object' && message !== null && message.val !== undefined
+                ? message.val !== null
+                    ? typeof message.val
+                    : 'mixed'
+                : typeof message;
         const obj = topic2id[topic].obj;
         if (
             namespaceRegEx.test(id) &&
@@ -629,13 +637,19 @@ function MQTTServer(adapter, states) {
                     },
                     type: 'state',
                 };
-                if (
+                if (!adapter.config.allBinaries && obj.common.type === 'object') {
+                    if (message !== undefined && message.val !== undefined && message.val !== null) {
+                        obj.common.type = typeof message.val;
+                    } else {
+                        obj.common.type = 'mixed';
+                    }
+                } else if (
                     !adapter.config.allBinaries &&
-                    obj.common.type === 'object' &&
+                    obj.common.type === 'string' &&
                     message !== undefined &&
-                    message.val !== undefined
+                    message[0] === '{'
                 ) {
-                    obj.common.type = typeof message.val;
+                    obj.common.type = 'mixed';
                 }
 
                 adapter.log.debug(`Create object for topic: ${topic}[ID: ${id}]`);

--- a/test/testSimClient.js
+++ b/test/testSimClient.js
@@ -34,6 +34,28 @@ describe('MQTT client', function () {
         }, 200);
     });
 
+    it('MQTT client: New topic with {val:null} payload should get type "mixed"', done => {
+        const topic = 'clientTypetestNull';
+        // A separate MQTT client publishes to the simulated broker;
+        // the broker forwards it to the ioBroker client adapter under test.
+        const publisher = new ClientEmitter(
+            isConnected => {
+                if (isConnected) {
+                    publisher.publish(topic, JSON.stringify({ val: null }));
+                    setTimeout(async () => {
+                        const obj = await adapter.getForeignObjectAsync(`mqtt.0.${topic}`);
+                        expect(obj).to.exist;
+                        expect(obj.common.type).to.equal('mixed');
+                        publisher.destroy();
+                        done();
+                    }, 500);
+                }
+            },
+            null,
+            { url: `127.0.0.1:${port}`, clean: true, clientId: 'clientTypeTestPublisher', subscribe: false },
+        );
+    }).timeout(3000);
+
     after('MQTT simulatedServer: Stop MQTT simulatedServer', done => {
         simulatedServer.stop(done);
         client.destroy();

--- a/test/testSimServer.js
+++ b/test/testSimServer.js
@@ -300,6 +300,55 @@ describe('MQTT server', function () {
         });
     }).timeout(3000);
 
+    it('MQTT server: New topic with {val:null} payload should get type "mixed"', () => {
+        let emitterClient;
+        const topic = 'typetestNull';
+        return new Promise(resolve => {
+            emitterClient = new Client(
+                isConnected => {
+                    if (isConnected) {
+                        emitterClient.publish(topic, JSON.stringify({ val: null }));
+                        setTimeout(() => resolve(), 300);
+                    }
+                },
+                null,
+                { url: `127.0.0.1:${port}`, clean: true, clientId: 'typeTestNullClient' },
+            );
+        }).then(async () => {
+            const obj = await adapter.getForeignObjectAsync(`mqtt.0.${topic}`);
+            expect(obj).to.exist;
+            expect(obj.common.type).to.equal('mixed');
+            emitterClient.destroy();
+        });
+    }).timeout(2000);
+
+    it('MQTT server: Existing numeric topic should keep type "number" after repeated JSON state publish', () => {
+        let emitterClient;
+        const topic = 'typetestNumber';
+        return new Promise(resolve => {
+            emitterClient = new Client(
+                isConnected => {
+                    if (isConnected) {
+                        // First publish: creates topic with type 'number'
+                        emitterClient.publish(topic, JSON.stringify({ val: 42 }));
+                        setTimeout(() => {
+                            // Second publish: must not flip type to 'object'
+                            emitterClient.publish(topic, JSON.stringify({ val: 7 }));
+                            setTimeout(() => resolve(), 300);
+                        }, 300);
+                    }
+                },
+                null,
+                { url: `127.0.0.1:${port}`, clean: true, clientId: 'typeTestNumberClient' },
+            );
+        }).then(async () => {
+            const obj = await adapter.getForeignObjectAsync(`mqtt.0.${topic}`);
+            expect(obj).to.exist;
+            expect(obj.common.type).to.equal('number');
+            emitterClient.destroy();
+        });
+    }).timeout(3000);
+
     after('MQTT server: Stop MQTT server', done => {
         server.destroy(done);
     });


### PR DESCRIPTION
Two bugs in the initial type assignment when a new MQTT topic is first seen:

1. In client.js (createObject): the type refinement check used `topic2id[topic].message.val` instead of the local `message` variable (which already holds the converted state object at that point), and had no guard for `val === null`, causing typeof null === 'object' to produce type 'object' instead of 'mixed'.

2. In server.js (checkObject): same missing null guard for val === null. Additionally, JSON strings whose properties are not all valid ioBroker state properties (e.g. `{event:'up', val:1}`) were left as type 'string' instead of being assigned 'mixed'.

3. In server.js (processTopic): `messageType` was derived from `typeof message` (always 'object' for ioBroker state format objects) instead of `typeof message.val`, causing the stored datapoint type to flip to 'object' and then 'mixed' on every subsequent publish.

Applies to both client mode (lib/client.js) and server mode (lib/server.js).

Fixes #517, #443

See also:

https://forum.iobroker.net/topic/77620/openhasp-erfahrung-nutzbar-ohne-adapter
https://forum.iobroker.net/topic/76093/fehler-mit-mqtt-adapter-forbidden-properties

