### PR TITLE
fix(subscribe): reject unresolved topic ids with SUBACK failure

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1186,13 +1186,19 @@ function MQTTServer(adapter, states) {
 
                     // if pattern without wildcards
                     if (!id.includes('*') && !id.includes('#') && !id.includes('+')) {
-                        // If state is unknown => create mqtt.X.topic
-                        if (!topic2id[topic]) {
+                        // Resolve topic to a valid id (await checkObject if needed), otherwise reject (0x80)
+                        if (!topic2id[topic]?.id) {
                             try {
                                 await checkObject(id, topic);
                             } catch {
-                                return;
+                                granted[i] = 0x80;
+                                continue;
                             }
+                        }
+                        
+                        if (!topic2id[topic]?.id) {
+                            granted[i] = 0x80;
+                            continue;
                         }
 
                         client._subsID[topic2id[topic].id] = {


### PR DESCRIPTION
Race condition during broker startup or reconnect:

- first client initializes topic2id[topic] with { id: null }
- second client subscribes before resolution completes
- existing code only checks topic existence, not id validity
- leads to subscription being registered with id=null
- client receives SUBACK success but never gets updates

Fix:

- check topic2id[topic]?.id instead of only existence
- await checkObject when id is missing or null
- reject unresolved topics with SUBACK 0x80
- continue processing remaining topics in the same SUBSCRIBE packet